### PR TITLE
while replacement

### DIFF
--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -113,6 +113,7 @@ class GATTCharacteristic(object):
 class ProcedureManager(object):
     def __init__(self):
         self._event = Event()
+        self.type = False
 
     def start_procedure(self, type):
         self.type = type

--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -5,6 +5,7 @@ import operator
 from api import BlueGigaAPI, BlueGigaCallbacks
 from cmd_def import gap_discoverable_mode, gap_connectable_mode, gap_discover_mode, \
     connection_status_mask, sm_io_capability, RESULT_CODE
+from threading import Event
 import logging
 import sys
 
@@ -111,22 +112,18 @@ class GATTCharacteristic(object):
 
 class ProcedureManager(object):
     def __init__(self):
-        self.procedure_in_progress = False
+        self._event = Event()
 
     def start_procedure(self, type):
-        self.procedure_in_progress = type
+        self.type = type
+        self._event.clear()
 
     def wait_for_procedure(self, timeout=3):
-        start = time.time()
-        while (self.procedure_in_progress and time.time() < start + timeout):
-            pass
-        if time.time() > start + timeout:
-            return False
-        return True
+        return self._event.wait(timeout)
 
     def procedure_complete(self, type):
-        if (self.procedure_in_progress == type):
-            self.procedure_in_progress = False
+        if self.type == type:
+            self._event.set()
 
 
 class BLEConnection(ProcedureManager):


### PR DESCRIPTION
Hi,

this is not regular pull request, but I want to bring you attention some trouble I have found.

I have experimentally replaced one of the while loops with Event and found one of the tests failing. It starts emitting some events before any command is send. This is probably caused by previous command which cause event emission, but reset of device to default state does not happen soon enough. You can derive simple fix for master branch from the last patch, so You can reject this request, but I'm interested whatever you can reproduce this behaviour (checkout one commit before this branch head).

There is still niche chance I have done something wrong, but not found anything so far.

I have one more question to discussion. In the higher level API (module.py) You are using the same locking mechanism for both responses and events. This seems wrong to my. It would be nice to have "middle level" API which waits synchronously for response on command (you cannot send another command until you get response), but event should be still handled asynchronously. I'm thinking about some way to implement it, but I want to know if this seems acceptible idea to You.
