### PR TITLE
Make BLEScanResponse.parse_advertisement_data() compatible with python 3

### DIFF
--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -44,22 +44,22 @@ class BLEScanResponse(object):
             gap_data = remaining[1:length+1]
 
             adv_seg={}
-            adv_seg_type, = struct.unpack('B', gap_data[0])
+            adv_seg_type, = struct.unpack('B', gap_data[:1])
             adv_seg["Type"] = self.get_ad_type_string(adv_seg_type)
             adv_seg["Data"] = gap_data[1:]
             self.adv_payload.append( adv_seg)
             #print("GAP Data: %s" % ("".join(["\\x%02x" % ord(i) for i in gap_data])))
             remaining = remaining[length+1:]
 
-            if gap_data[0] == 0x1:  # Flags
+            if adv_seg_type == 0x1:  # Flags
                 pass
-            elif gap_data[0] == b"\x02" or gap_data[0] == b"\x03":  # Incomplete/Complete list of 16-bit UUIDs
+            elif adv_seg_type == 0x02 or adv_seg_type == 0x03:  # Incomplete/Complete list of 16-bit UUIDs
                 for i in range((len(gap_data) - 1)/2):
                     self.services += [gap_data[2*i+1:2*i+3]]
-            elif gap_data[0] == b"\x04" or gap_data[0] == b"\x05":  # Incomplete list of 32-bit UUIDs
+            elif adv_seg_type == 0x04 or adv_seg_type == 0x05:  # Incomplete list of 32-bit UUIDs
                 for i in range((len(gap_data) - 1)/4):
                     self.services += [gap_data[4*i+1:4*i+5]]
-            elif gap_data[0] == b"\x06" or gap_data[0] == b"\x07":  # Incomplete list of 128-bit UUIDs
+            elif adv_seg_type == 0x06 or adv_seg_type == 0x07:  # Incomplete list of 128-bit UUIDs
                 for i in range((len(gap_data) - 1)/16):
                     self.services += [gap_data[16*i+1:16*i+17]]
 
@@ -67,7 +67,7 @@ class BLEScanResponse(object):
         self.parse_advertisement_data()
         return self.services
 
-    def get_ad_type_string(self, type):
+    def get_ad_type_string(self, type_ord):
         return {
             0x01: "BLE_GAP_AD_TYPE_FLAGS",
             0x02: "BLE_GAP_AD_TYPE_16BIT_SERVICE_UUID_MORE_AVAILABLE",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_long_description():
 setup(
   name='bgapi',
   packages=['bgapi'],
-  version='0.5',
+  version='0.5.1',
   description='Interface library for BlueGiga BLE112 and BLE113 modules',
   long_description=get_long_description(),
   url='https://github.com/mjbrown/bgapi',


### PR DESCRIPTION
This pull request fixes 3 issues with the BLEScanResponse.parse_advertisement_data():
- Indexing a bytes array in py 3 returns an int. in py 2 it returns a bytes object with size 1,
  Slicing it will return a bytes object in py 2 and 3.
- Extracting services from the advertising data is not consistent when comparing the type field.
- get_ad_type_string() method parameter name is wrong.

Code to test it:
----
```python
client = BlueGigaClient(port='...')
rsp = client.scan_all()
rsp[0].parse_advertisement_data()
```
Test only works if nearby devices are currently advertising.

I could not yet test this exact pull request as I will have access to BLED112 dongles on Tuesday again.