### PR TITLE
Make BLEScanResponse.parse_advertisement_data() parse service UUIDs correctly for python 3.

### DIFF
--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -54,14 +54,14 @@ class BLEScanResponse(object):
             if adv_seg_type == 0x1:  # Flags
                 pass
             elif adv_seg_type == 0x02 or adv_seg_type == 0x03:  # Incomplete/Complete list of 16-bit UUIDs
-                for i in range((len(gap_data) - 1)/2):
-                    self.services += [gap_data[2*i+1:2*i+3]]
+                for i in range(1, len(gap_data) - 1, 2):
+                    self.services += [gap_data[i:i+2]]
             elif adv_seg_type == 0x04 or adv_seg_type == 0x05:  # Incomplete list of 32-bit UUIDs
-                for i in range((len(gap_data) - 1)/4):
-                    self.services += [gap_data[4*i+1:4*i+5]]
+                for i in range(1, len(gap_data) - 3, 4):
+                    self.services += [gap_data[i:i+4]]
             elif adv_seg_type == 0x06 or adv_seg_type == 0x07:  # Incomplete list of 128-bit UUIDs
-                for i in range((len(gap_data) - 1)/16):
-                    self.services += [gap_data[16*i+1:16*i+17]]
+                for i in range(1, len(gap_data) - 15, 16):
+                    self.services += [gap_data[i:i+16]]
 
     def get_services(self):
         self.parse_advertisement_data()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_long_description():
 setup(
   name='bgapi',
   packages=['bgapi'],
-  version='0.5.1',
+  version='0.5.2',
   description='Interface library for BlueGiga BLE112 and BLE113 modules',
   long_description=get_long_description(),
   url='https://github.com/mjbrown/bgapi',


### PR DESCRIPTION
There was another python 3 bug that appeared while testing with a device that advertises service UUID values inside the advertising payload.

Here is the fix, tested with python 2.7 and 3.4.

Test code:
```python
from bgapi.module import BlueGigaClient

client = BlueGigaClient(port='COM8')
client.active_scan()
rsp = client.scan_all(timeout=5)
client.disable_scan()
services = set()
for r in rsp:
    services.update(set(r.get_services()))

print('ok %d' % len(rsp))
print(services)
```
