### PR TITLE
Minor improvements.

### DIFF
--- a/bgapi/api.py
+++ b/bgapi/api.py
@@ -4,6 +4,7 @@ import struct
 import serial
 import logging
 import sys
+import traceback
 
 from binascii import hexlify
 from .cmd_def import RESULT_CODE, ATTRIBUTE_CHANGE_REASON, ATTRIBUTE_STATUS_FLAGS, ATTRIBUTE_VALUE_TYPE
@@ -45,7 +46,11 @@ class BlueGigaAPI(object):
                 break
             packet, self.rx_buffer = self.rx_buffer[:self._packet_size], self.rx_buffer[self._packet_size:]
             self._packet_size = 4
-            self.parse_bgapi_packet(packet)
+            
+            try:
+                self.parse_bgapi_packet(packet)
+            except:
+                traceback.print_exc()
 
     def start_daemon(self):
         """

--- a/bgapi/api.py
+++ b/bgapi/api.py
@@ -49,8 +49,8 @@ class BlueGigaAPI(object):
             
             try:
                 self.parse_bgapi_packet(packet)
-            except:
-                traceback.print_exc()
+            except Exception:
+                logger.exception("Error parsing bgapi packet.")
 
     def start_daemon(self):
         """

--- a/bgapi/cmd_def.py
+++ b/bgapi/cmd_def.py
@@ -1,77 +1,101 @@
-RESULT_CODE = {0x0000: "OK",
-               0x0180: "Invalid Parameter",
-               0x0181: "Device in Wrong State",
-               0x0182: "Out Of Memory",
-               0x0183: "Feature Not Implemented",
-               0x0184: "Command Not Recognized",
-               0x0185: "Timeout",
-               0x0186: "Not Connected",
-               0x0187: "Flow",
-               0x0188: "User Attribute",
-               0x0189: "Invalid License Key",
-               0x018A: "Command Too Long",
-               0x018B: "Out of Bounds",
-               0x0205: "Authentication Failure",
-               0x0206: "Pin Or Key Missing",
-               0x0207: "Memory Capacity Exceeded",
-               0x0208: "Connection Timeout",
-               0x0209: "Connection Limit Exceeded",
-               0x020C: "Command Disallowed",
-               0x0212: "Invalid Command Parameters",
-               0x0213: "Remote User Terminated Connection",
-               0x0216: "Connection Terminated by Local Host",
-               0x0222: "Link Layer Timeout",
-               0x0228: "Link Layer Instant Passed",
-               0x023A: "Controller Busy",
-               0x023B: "Unacceptable Connection Interval",
-               0x023C: "Directed Advertising Timeout",
-               0x023D: "Message Integrity Check Failure",
-               0x023E: "Connection Failed to be Established",
-               0x0301: "Passkey Entry Failed",
-               0x0302: "Out of Band Data is Not Available",
-               0x0303: "Authentication Requirements",
-               0x0304: "Confirm Value Failed",
-               0x0305: "Pairing Not Supported",
-               0x0306: "Encryption Key Size",
-               0x0307: "Command Not Supported",
-               0x0308: "Unspecified Pairing Failure",
-               0x0309: "Repeated Attempts",
-               0x030A: "Invalid Parameters",
-               0x0401: "Invalid Handle",
-               0x0402: "Read Not Permitted",
-               0x0403: "Write Not Permitted",
-               0x0404: "Invalid PDU",
-               0x0405: "Insufficient Authentication",
-               0x0406: "Request Not Supported",
-               0x0407: "Invalid Offset",
-               0x0408: "Insufficient Authorization",
-               0x0409: "Prepare Queue Full",
-               0x040A: "Attribute Not Found",
-               0x040B: "Attribute Not Long",
-               0x040C: "Insufficient Encryption Key Size",
-               0x040D: "Invalid Attribute Value Length",
-               0x040E: "Unlikely Error",
-               0x040F: "Insufficient Encryption",
-               0x0410: "Unsupported Group Type",
-               0x0411: "Insufficient Resources",
-               0x0480: "Application Error Codes",
-               }
+class ReturnCodeLookupDict(object):
+   """A return code lookup dict that returns a default placeholder string if requested code is not present in the original table."""
 
-ATTRIBUTE_CHANGE_REASON = {0x0: "Write Request",
-                           0x1: "Write Command",
-                           0x2: "Write Request User"}
+   def __init__(self, lookup):
+      self._lookup = lookup
 
-ATTRIBUTE_STATUS_FLAGS = {0x0: "No Notifications or Indications",
-                          0x1: "Notification",
-                          0x2: "Indication",
-                          0x3: "Notification and Indication"}
+   def __getitem__(self, code):
+      try:
+         rv = self._lookup.get(code)
+      except KeyError:
+         rv = "Unknown Code 0x%02X"
+      return rv
 
-ATTRIBUTE_VALUE_TYPE = {0x0: "Read",
-                        0x1: "Notification",
-                        0x2: "Indication",
-                        0x3: "Read By Type",
-                        0x4: "Read Blob",
-                        0x5: "Indication Response Requested"}
+   def get(self, code, default=None):
+      return self._lookup.get(code, default)
+
+RESULT_CODE = ReturnCodeLookupDict({
+   0x0000: "OK",
+   0x0180: "Invalid Parameter",
+   0x0181: "Device in Wrong State",
+   0x0182: "Out Of Memory",
+   0x0183: "Feature Not Implemented",
+   0x0184: "Command Not Recognized",
+   0x0185: "Timeout",
+   0x0186: "Not Connected",
+   0x0187: "Flow",
+   0x0188: "User Attribute",
+   0x0189: "Invalid License Key",
+   0x018A: "Command Too Long",
+   0x018B: "Out of Bounds",
+   0x0205: "Authentication Failure",
+   0x0206: "Pin Or Key Missing",
+   0x0207: "Memory Capacity Exceeded",
+   0x0208: "Connection Timeout",
+   0x0209: "Connection Limit Exceeded",
+   0x020C: "Command Disallowed",
+   0x0212: "Invalid Command Parameters",
+   0x0213: "Remote User Terminated Connection",
+   0x0216: "Connection Terminated by Local Host",
+   0x0222: "Link Layer Timeout",
+   0x0228: "Link Layer Instant Passed",
+   0x023A: "Controller Busy",
+   0x023B: "Unacceptable Connection Interval",
+   0x023C: "Directed Advertising Timeout",
+   0x023D: "Message Integrity Check Failure",
+   0x023E: "Connection Failed to be Established",
+   0x0301: "Passkey Entry Failed",
+   0x0302: "Out of Band Data is Not Available",
+   0x0303: "Authentication Requirements",
+   0x0304: "Confirm Value Failed",
+   0x0305: "Pairing Not Supported",
+   0x0306: "Encryption Key Size",
+   0x0307: "Command Not Supported",
+   0x0308: "Unspecified Pairing Failure",
+   0x0309: "Repeated Attempts",
+   0x030A: "Invalid Parameters",
+   0x0401: "Invalid Handle",
+   0x0402: "Read Not Permitted",
+   0x0403: "Write Not Permitted",
+   0x0404: "Invalid PDU",
+   0x0405: "Insufficient Authentication",
+   0x0406: "Request Not Supported",
+   0x0407: "Invalid Offset",
+   0x0408: "Insufficient Authorization",
+   0x0409: "Prepare Queue Full",
+   0x040A: "Attribute Not Found",
+   0x040B: "Attribute Not Long",
+   0x040C: "Insufficient Encryption Key Size",
+   0x040D: "Invalid Attribute Value Length",
+   0x040E: "Unlikely Error",
+   0x040F: "Insufficient Encryption",
+   0x0410: "Unsupported Group Type",
+   0x0411: "Insufficient Resources",
+   0x0480: "Application Error Codes",
+   })
+
+
+ATTRIBUTE_CHANGE_REASON = ReturnCodeLookupDict({
+   0x0: "Write Request",
+   0x1: "Write Command",
+   0x2: "Write Request User"
+   })
+
+ATTRIBUTE_STATUS_FLAGS = ReturnCodeLookupDict({
+   0x0: "NoNotifications or Indications",
+   0x1: "Notification",
+   0x2: "Indication",
+   0x3: "Notification and Indication"
+   })
+
+ATTRIBUTE_VALUE_TYPE = ReturnCodeLookupDict({
+   0x0: "Read",
+   0x1: "Notification",
+   0x2: "Indication",
+   0x3: "Read By Type",
+   0x4: "Read Blob",
+   0x5: "Indication Response Requested"
+   })
 
 system_endpoints= {
 	'system_endpoint_api': 0,

--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -1,26 +1,56 @@
 from __future__ import absolute_import
+
+import logging
+import sys
 import time
 import struct
 import operator
 
+from functools import wraps
+from contextlib import contextmanager
+from collections import defaultdict, namedtuple
+from threading import Event, Lock
+
 from .api import BlueGigaAPI, BlueGigaCallbacks
 from .cmd_def import gap_discoverable_mode, gap_connectable_mode, gap_discover_mode, \
-    connection_status_mask, sm_io_capability
-from threading import Event
-import logging
-import sys
+    connection_status_mask, sm_io_capability, RESULT_CODE
+
 
 GET_ADDRESS = "Read Address in Progress"
 PROCEDURE = "Procedure in Progress"
 START_ENCRYPTION = "Start Encryption in Progress"
 READ_ATTRIBUTE = "Attribute Read in Progress"
+WRITE_ATTRIBUTE = "Attribute Write in Progress"
 CONNECT = "Connection Attempt in Progress"
 DISCONNECT = "Disconnect in Progress"
 CONN_PARAM_UPDATE = "Connection Parameter Update Expected"
 
+MAX_CONNECTIONS = 8
+
 class BlueGigaModuleException(Exception):
     pass
 
+class Timeout(BlueGigaModuleException):
+    """Procedure type module timeout."""
+
+class RemoteError(BlueGigaModuleException):
+
+    def __init__(self, resultCode):
+        self.code = resultCode
+        self.text = RESULT_CODE.get(self.code, "UNKNOWN")
+
+        super(RemoteError, self).__init__("0x%04X: %s" % (self.code, self.text))
+
+class Disconnected(BlueGigaModuleException):
+
+    def __init__(self, resultCode, extraMsg=""):
+        self.code = resultCode
+        self.text = RESULT_CODE.get(self.code, "UNKNOWN")
+        self.extraMsg = extraMsg
+
+        super(Disconnected, self).__init__("0x%04X: %s %s" % (self.code, self.text, self.extraMsg))
+
+AdvancedSegment = namedtuple("AdvancedSegment", ["type_code", "type_name", "data"])
 
 class BLEScanResponse(object):
     def __init__(self, rssi, packet_type, sender, address_type, bond, data):
@@ -43,11 +73,13 @@ class BLEScanResponse(object):
             length, = struct.unpack('B', remaining[:1])
             gap_data = remaining[1:length+1]
 
-            adv_seg={}
-            adv_seg_type, = struct.unpack('B', gap_data[:1])
-            adv_seg["Type"] = self.get_ad_type_string(adv_seg_type)
-            adv_seg["Data"] = gap_data[1:]
-            self.adv_payload.append( adv_seg)
+            (adv_seg_type,) = struct.unpack('B', gap_data[:1])
+            try:
+                adv_seg_name = self.get_ad_type_string(adv_seg_type)
+            except KeyError:
+                adv_seg_name = None
+
+            self.adv_payload.append(AdvancedSegment(adv_seg_type, adv_seg_name, gap_data[1:]))
             #print("GAP Data: %s" % ("".join(["\\x%02x" % ord(i) for i in gap_data])))
             remaining = remaining[length+1:]
 
@@ -162,24 +194,61 @@ class GATTCharacteristic(object):
             return self.descriptors[uuid]
 
 
+class ProcedureCallHandle(object):
+
+    __slots__ = ("event", "result")
+
+    def __init__(self):
+        self.event = Event()
+
+    def setResult(self, result):
+        self.result = result
+        self.event.set()
+
 class ProcedureManager(object):
     def __init__(self):
-        self._event = Event()
-        self._procedure_type = False
-        self._procedure_result = 0
+        self._typeLocks = defaultdict(Lock) # procedure type -> execution lock for that
+        self._handles = {} # procedure type -> <ProcedureCallHandle>
+        
+    @contextmanager
+    def procedure_call(self, procedure_type, timeout, throwError=True):
+        with self._typeLocks[procedure_type]:
+            assert procedure_type not in self._handles # Nobody else is waiting for this procedure type
+            
+            handle = ProcedureCallHandle()
+            self._handles[procedure_type] = handle
+            try:
 
-    def start_procedure(self, procedure_type):
-        self._procedure_type = procedure_type
-        self._procedure_result = 0x0000
-        self._event.clear()
+                yield handle # allow the caller to execute his API call in this context.
+                # the Result pair can be used by the context for
+                
 
-    def wait_for_procedure(self, timeout=3):
-        return self._event.wait(timeout)
+                if not handle.event.wait(timeout):
+                    raise Timeout("Procedure call timed out")
+
+                if throwError and handle.result != 0x0000:
+                    raise RemoteError(handle.result)
+            finally:
+                del self._handles[procedure_type]
+
 
     def procedure_complete(self, procedure_type, result=0x0000):
-        self._procedure_result = result
-        if self._procedure_type == procedure_type:
-            self._event.set()
+        try:
+            handle = self._handles[procedure_type]
+        except KeyError:
+            # This procedure had not been started, ignore the result
+            return
+        handle.setResult(result)
+
+def connected(fn):
+    """This decorator checks that the BLEConnection is still connected before executing the payload function."""
+    @wraps(fn)
+    def _wrapper_(self, *args, **kwargs):
+        if self._disconnected is not None:
+            raise Disconnected(self._disconnected, "This connection is no longer connected")
+        return fn(self, *args, **kwargs)
+
+    return _wrapper_
 
 
 class BLEConnection(ProcedureManager):
@@ -199,6 +268,13 @@ class BLEConnection(ProcedureManager):
         self.uuid_handle = {}
         self.handle_value = {}
         self.attrclient_value_cb = {}
+        self._disconnected = None
+
+    def is_connected(self):
+        return self._disconnected is None
+
+    def set_disconnected(self, reason):
+        self._disconnected = reason
 
     def get_conn_interval_ms(self):
         return self.interval * 1.25
@@ -250,92 +326,89 @@ class BLEConnection(ProcedureManager):
         if handle in self.attrclient_value_cb:
             self.attrclient_value_cb[handle](value)
 
+    @connected
     def read_by_group_type(self, group_type, timeout=3):
-        self.start_procedure(PROCEDURE)
-        self._api.ble_cmd_attclient_read_by_group_type(self.handle, 1, 65535, group_type)
-        if not self.wait_for_procedure(timeout=timeout):
-            raise BlueGigaModuleException("Read By Group procedure did not complete before timeout!")
+        with self.procedure_call(PROCEDURE, timeout):
+            self._api.ble_cmd_attclient_read_by_group_type(self.handle, 1, 65535, group_type)
 
+    @connected
     def read_by_type(self, service, type, timeout=3):
-        self.start_procedure(PROCEDURE)
-        self._api.ble_cmd_attclient_read_by_type(self.handle, service.start_handle, service.end_handle, type)
-        if not self.wait_for_procedure(timeout=timeout):
-            raise BlueGigaModuleException("Read By Type procedure did not complete before timeout!")
+        with self.procedure_call(PROCEDURE, timeout):
+            self._api.ble_cmd_attclient_read_by_type(self.handle, service.start_handle, service.end_handle, type)
 
+    @connected
     def find_information(self, service, timeout=5):
-        self.start_procedure(PROCEDURE)
-        self._api.ble_cmd_attclient_find_information(self.handle, service.start_handle, service.end_handle)
-        if not self.wait_for_procedure(timeout=timeout):
-            raise BlueGigaModuleException("Find Information did not complete before timeout!")
+        with self.procedure_call(PROCEDURE, timeout):
+            self._api.ble_cmd_attclient_find_information(self.handle, service.start_handle, service.end_handle)
 
+    @connected
     def read_by_handle(self, handle, timeout=3):
-        self.start_procedure(READ_ATTRIBUTE)
-        self._api.ble_cmd_attclient_read_by_handle(self.handle, handle)
-        if not self.wait_for_procedure(timeout=timeout):
-            raise BlueGigaModuleException("Read Attribute by Handle did not complete before timeout!")
+        with self.procedure_call(PROCEDURE, timeout):
+            self._api.ble_cmd_attclient_read_by_handle(self.handle, handle)
 
     def write_by_uuid(self, uuid, value, timeout=3):
         for handle in self.uuid_handle[uuid]:
             self.write_by_handle(handle, value, timeout)
 
+    @connected
     def write_by_handle(self, handle, value, timeout=3):
-        self.start_procedure(PROCEDURE)
-        self._api.ble_cmd_attclient_attribute_write(self.handle, handle, value)
-        if not self.wait_for_procedure(timeout=timeout):
-            raise BlueGigaModuleException("Write did not complete before timeout! Connection:%d - Handle:%d" % (self.handle, handle))
+        with self.procedure_call(WRITE_ATTRIBUTE, timeout):
+            self._api.ble_cmd_attclient_attribute_write(self.handle, handle, value)
 
     def wr_noresp_by_uuid(self, uuid, value, timeout=3):
         for handle in self.uuid_handle[uuid]:
             self.wr_noresp_by_handle(handle, value, timeout)
 
+    @connected
     def wr_noresp_by_handle(self, handle, value, timeout=3, attempts=1):
         for i in range(attempts):
-            self.start_procedure(PROCEDURE)
-            self._api.ble_cmd_attclient_write_command(self.handle, handle, value)
-            if not self.wait_for_procedure(timeout=timeout):
-                raise BlueGigaModuleException("Write without response did not complete before timeout! Connection:%d - Handle:%d" % (self.handle, handle))
-            if self._procedure_result != 0x0000:
+
+            with self.procedure_call(PROCEDURE, timeout, throwError=False) as handle:
+                self._api.ble_cmd_attclient_write_command(self.handle, handle, value)
+
+            if handle.result != 0x0000:
                 time.sleep(self.interval * 0.00125)  # Sleep for a connection interval
             else:
                 break
 
     def read_long_by_uuid(self, uuid, timeout=3):
         for handle in self.uuid_handle[uuid]:
-            self.read_long_by_handle(self.uuid_handle[uuid])
+            self.read_long_by_handle(self.uuid_handle[uuid], timeout)
 
+    @connected
     def read_long_by_handle(self, handle, timeout=3):
-        self.start_procedure(PROCEDURE)
-        self._api.ble_cmd_attclient_read_long(self.handle, handle)
-        if not self.wait_for_procedure(timeout=timeout):
-            raise BlueGigaModuleException("Long Read did not complete before timeout! Connection:%d - Handle:%d" % self.handle, handle)
+        with self.procedure_call(PROCEDURE, timeout):
+            self._api.ble_cmd_attclient_read_long(self.handle, handle)
 
     def reliable_write_by_uuid(self, uuid, value, offset=0, timeout=3):
         for handle in self.uuid_handle[uuid]:
             self.reliable_write_by_handle(handle, value, offset, timeout)
 
+    @connected
     def reliable_write_by_handle(self, handle, value, offset=0, timeout=3):
         for i in range((len(value) / 20)+1):
             chunk = value[20*i+offset:min(20*(i+1)+offset, len(value))]
-            self.start_procedure(PROCEDURE)
-            self._api.ble_cmd_attclient_prepare_write(self.handle, handle, 20*i+offset, chunk)
-            self.wait_for_procedure(timeout=timeout)
-        self.start_procedure(PROCEDURE)
-        self._api.ble_cmd_attclient_execute_write(self.handle, 1) # 1 = commit, 0 = cancel
-        self.wait_for_procedure(timeout=timeout)
+            with self.procedure_call(PROCEDURE, timeout):
+                self._api.ble_cmd_attclient_prepare_write(self.handle, handle, 20*i+offset, chunk)
+
+        with self.procedure_call(PROCEDURE, timeout):
+            self._api.ble_cmd_attclient_execute_write(self.handle, 1) # 1 = commit, 0 = cancel
 
     def characteristic_subscription(self, characteristic, indicate=True, notify=True, timeout=1):
         descriptor = characteristic.get_descriptor_by_uuid(GATTCharacteristic.CLIENT_CHARACTERISTIC_CONFIG)
         if not descriptor:
             raise BlueGigaModuleException("Unable to find Client Characteristic Config (must Read by Type 0x2902)")
         config = struct.pack('BB', (2 if indicate else 0) + (1 if notify else 0), 0)
-        self.write_by_handle(descriptor.handle, config, timeout=timeout)
+        with self.procedure_call(PROCEDURE, timeout):
+            self.write_by_handle(descriptor.handle, config, timeout=timeout)
 
+    @connected
     def request_encryption(self, bond=True, timeout=1):
-        self.start_procedure(START_ENCRYPTION)
-        self._api.ble_cmd_sm_encrypt_start(self.handle, 1 if bond else 0)
-        if not self.wait_for_procedure(timeout=timeout):
-            raise BlueGigaModuleException("Start Encryption did not complete before timeout!")
+        with self.procedure_call(START_ENCRYPTION, timeout):
+            self._api.ble_cmd_sm_encrypt_start(self.handle, 1 if bond else 0)
 
+    def close(self):
+        self._api.disconnect(self.handle)
 
 class BlueGigaModule(BlueGigaCallbacks, ProcedureManager):
     CONNECTION_OBJECT = BLEConnection
@@ -370,28 +443,34 @@ class BlueGigaModule(BlueGigaCallbacks, ProcedureManager):
         return self._module_info
 
     def get_ble_address(self, timeout=1):
-        self.start_procedure(GET_ADDRESS)
-        self._api.ble_cmd_system_address_get()
-        if not self.wait_for_procedure(timeout=timeout):
-            raise BlueGigaModuleException("No response to get_ble_address!")
-        else:
-            return self.address
+        with self.procedure_call(GET_ADDRESS, timeout) as handle:
+            self._api.ble_cmd_system_address_get()
+        return self.address
 
     def reset_ble_state(self):
         """ Disconnect, End Procedure, and Disable Advertising """
         self._api.ble_cmd_gap_set_mode(gap_discoverable_mode['gap_non_discoverable'],
                                        gap_connectable_mode['gap_non_connectable'])
-        for i in range(8):
-            self.disconnect(i)
+        for i in range(MAX_CONNECTIONS):
+            try:
+                self.disconnect(i)
+            except RemoteError:
+                pass
         self._api.ble_cmd_gap_end_procedure()
 
     def disconnect(self, connection):
-        self.start_procedure(DISCONNECT)
         try:
-            self._api.ble_cmd_connection_disconnect(connection=connection.handle)
-        except AttributeError:
-            self._api.ble_cmd_connection_disconnect(connection=connection)
-        self.wait_for_procedure()
+            with self.procedure_call(DISCONNECT, timeout=None):
+                try:
+                    self._api.ble_cmd_connection_disconnect(connection=connection.handle)
+                except AttributeError:
+                    self._api.ble_cmd_connection_disconnect(connection=connection)
+        except RemoteError as err:
+            if err.code == 0x0186:
+                # Not connected
+                pass
+            else:
+                raise
 
     def allow_bonding(self):
         self._api.ble_cmd_sm_set_bondable_mode(1)
@@ -443,11 +522,14 @@ class BlueGigaModule(BlueGigaCallbacks, ProcedureManager):
 
     def ble_rsp_connection_disconnect(self, connection, result):
         super(BlueGigaModule, self).ble_rsp_connection_disconnect(connection, result)
-        if result == 0x0186: # Not Connected
-            self.procedure_complete(DISCONNECT, result=result)
+        if connection in self.connections:
+            self.connections[connection].set_disconnected(result)
+        self.procedure_complete(DISCONNECT, result=result)
 
     def ble_evt_connection_disconnected(self, connection, reason):
         super(BlueGigaModule, self).ble_evt_connection_disconnected(connection, reason)
+        if connection in self.connections:
+            self.connections[connection].set_disconnected(reason)
         self.procedure_complete(DISCONNECT, result=reason)
 
 
@@ -476,15 +558,15 @@ class BlueGigaClient(BlueGigaModule):
         return self._api.ble_cmd_gap_set_scan_parameters(scan_interval, scan_window, 0)
 
     def connect(self, target, timeout=5, conn_interval_min=0x20, conn_interval_max=0x30, connection_timeout=100, latency=0):
-        self.start_procedure(CONNECT)
-        self._api.ble_cmd_gap_connect_direct(address=target.sender,
-                                             addr_type=target.address_type,
-                                             conn_interval_min=conn_interval_min,
-                                             conn_interval_max=conn_interval_max,
-                                             timeout=connection_timeout,
-                                             latency=latency)
-        if not self.wait_for_procedure(timeout=timeout):
-            raise BlueGigaModuleException("Connection attempt unsuccessful! (%s)" % target.get_sender_address())
+        with self.procedure_call(CONNECT, timeout):
+            self._api.ble_cmd_gap_connect_direct(
+                address=target.sender,
+                addr_type=target.address_type,
+                conn_interval_min=conn_interval_min,
+                conn_interval_max=conn_interval_max,
+                timeout=connection_timeout,
+                latency=latency
+            )
         return self.most_recent_connection
 
     def _scan(self, mode, timeout):
@@ -505,31 +587,35 @@ class BlueGigaClient(BlueGigaModule):
     #----------------  Events triggered by incoming data ------------------#
 
     def ble_evt_gap_scan_response(self, rssi, packet_type, sender, address_type, bond, data):
-        super(BlueGigaModule, self).ble_evt_gap_scan_response(rssi, packet_type, sender, address_type, bond, data)
+        super(BlueGigaClient, self).ble_evt_gap_scan_response(rssi, packet_type, sender, address_type, bond, data)
         if not self.scan_responses:
             self.scan_responses = []
         self.scan_responses += [ BLEScanResponse(rssi, packet_type, sender, address_type, bond, data) ]
 
     def ble_evt_attclient_find_information_found(self, connection, chrhandle, uuid):
-        super(BlueGigaModule, self).ble_evt_attclient_find_information_found(connection, chrhandle, uuid)
+        super(BlueGigaClient, self).ble_evt_attclient_find_information_found(connection, chrhandle, uuid)
         self.connections[connection].update_uuid(chrhandle, uuid)
 
     def ble_evt_attclient_attribute_value(self, connection, atthandle, type, value):
-        super(BlueGigaModule, self).ble_evt_attclient_attribute_value(connection, atthandle, type, value)
+        super(BlueGigaClient, self).ble_evt_attclient_attribute_value(connection, atthandle, type, value)
         if connection in self.connections:
             self.connections[connection].update_handle(atthandle, value)
             self.connections[connection].procedure_complete(READ_ATTRIBUTE)
 
     def ble_evt_attclient_group_found(self, connection, start, end, uuid):
-        super(BlueGigaModule, self).ble_evt_attclient_group_found(connection, start, end, uuid)
+        super(BlueGigaClient, self).ble_evt_attclient_group_found(connection, start, end, uuid)
         self.connections[connection].update_service(start, end, uuid)
 
     def ble_evt_attclient_procedure_completed(self, connection, result, chrhandle):
-        super(BlueGigaModule, self).ble_evt_attclient_procedure_completed(connection, result, chrhandle)
+        super(BlueGigaClient, self).ble_evt_attclient_procedure_completed(connection, result, chrhandle)
         self.procedure_complete(PROCEDURE, result=result)
         self.connections[connection].procedure_complete(PROCEDURE, result=result)
         self.connections[connection].procedure_complete(READ_ATTRIBUTE, result=result) # When the attribute read fails
 
+    def ble_rsp_attclient_attribute_write(self, connection, result):
+        super(BlueGigaClient, self).ble_rsp_attclient_attribute_write(connection, result)
+        self.procedure_complete(PROCEDURE, result=result)
+        self.connections[connection].procedure_complete(WRITE_ATTRIBUTE, result=result)
 
 class BlueGigaServer(BlueGigaModule):
     def __init__(self, port, baud=115200, timeout=0.1):
@@ -600,21 +686,18 @@ class BlueGigaServer(BlueGigaModule):
                                        connect=gap_connectable_mode['gap_undirected_connectable'])
 
     def write_attribute(self, handle, value, offset=0, timeout=1):
-        self.start_procedure(PROCEDURE)
-        self._api.ble_cmd_attributes_write(handle=handle, offset=offset, value=value)
-        self.wait_for_procedure(timeout=timeout)
+        with self.procedure_call(PROCEDURE, timeout):
+            self._api.ble_cmd_attributes_write(handle=handle, offset=offset, value=value)
 
     def read_by_handle(self, handle, offset, timeout):
-        self.start_procedure(PROCEDURE)
-        self._api.ble_cmd_attributes_read(handle, offset)
-        if self.wait_for_procedure(timeout=timeout):
-            return self.handle_values[handle]
+        with self.procedure_call(READ_ATTRIBUTE, timeout):
+            self._api.ble_cmd_attributes_read(handle, offset)
+        return self.handle_values[handle]
 
     def read_type(self, handle, timeout=1):
-        self.start_procedure(PROCEDURE)
-        self._api.ble_cmd_attributes_read_type(handle)
-        if self.wait_for_procedure(timeout=timeout):
-            return self.handle_types[handle]
+        with self.procedure_call(PROCEDURE, timeout):
+            self._api.ble_cmd_attributes_read_type(handle)
+        return self.handle_types[handle]
 
 
     #-------------------- Events triggered by incoming data ------------- #

--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -246,7 +246,7 @@ class BLEConnection(ProcedureManager):
                         characteristic.add_descriptor(self.handle_uuid[handle], handle, value)
                         break
         else:
-            raise BlueGigaModuleException("Attribute Value for Handle %d received with unknown UUID!" % (handle))
+            raise BlueGigaModuleException("Attribute Value for Handle %d received with unknown UUID!" % (handle, ))
         if handle in self.attrclient_value_cb:
             self.attrclient_value_cb[handle](value)
 
@@ -282,7 +282,7 @@ class BLEConnection(ProcedureManager):
         self.start_procedure(PROCEDURE)
         self._api.ble_cmd_attclient_attribute_write(self.handle, handle, value)
         if not self.wait_for_procedure(timeout=timeout):
-            raise BlueGigaModuleException("Write did not complete before timeout! Connection:%d - Handle:%d" % self.handle, handle)
+            raise BlueGigaModuleException("Write did not complete before timeout! Connection:%d - Handle:%d" % (self.handle, handle))
 
     def wr_noresp_by_uuid(self, uuid, value, timeout=3):
         for handle in self.uuid_handle[uuid]:
@@ -323,12 +323,12 @@ class BLEConnection(ProcedureManager):
         self._api.ble_cmd_attclient_execute_write(self.handle, 1) # 1 = commit, 0 = cancel
         self.wait_for_procedure(timeout=timeout)
 
-    def characteristic_subscription(self, characteristic, indicate=True, notify=True):
+    def characteristic_subscription(self, characteristic, indicate=True, notify=True, timeout=1):
         descriptor = characteristic.get_descriptor_by_uuid(GATTCharacteristic.CLIENT_CHARACTERISTIC_CONFIG)
         if not descriptor:
             raise BlueGigaModuleException("Unable to find Client Characteristic Config (must Read by Type 0x2902)")
         config = struct.pack('BB', (2 if indicate else 0) + (1 if notify else 0), 0)
-        self.write_by_handle(descriptor.handle, config, timeout=1)
+        self.write_by_handle(descriptor.handle, config, timeout=timeout)
 
     def request_encryption(self, bond=True, timeout=1):
         self.start_procedure(START_ENCRYPTION)

--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -15,6 +15,7 @@ from .api import BlueGigaAPI, BlueGigaCallbacks
 from .cmd_def import gap_discoverable_mode, gap_connectable_mode, gap_discover_mode, \
     connection_status_mask, sm_io_capability, RESULT_CODE
 
+logger = logging.getLogger(__name__)
 
 GET_ADDRESS = "Read Address in Progress"
 PROCEDURE = "Procedure in Progress"
@@ -322,7 +323,10 @@ class BLEConnection(ProcedureManager):
         else:
             raise BlueGigaModuleException("Attribute Value for Handle %d received with unknown UUID!" % (handle, ))
         if handle in self.attrclient_value_cb:
-            self.attrclient_value_cb[handle](value)
+            try:
+                self.attrclient_value_cb[handle](value)
+            except Exception:
+                logger.exception("Callback exception")
 
     @connected
     def read_by_group_type(self, group_type, timeout=3):


### PR DESCRIPTION
Hello,

This pull request contains few amendments to the bgapi code I had to do for my [PyPush](https://github.com/VRGhost/PyPush) Project.

So, in the order of decreasing importance:

1. bgapi/module.py

1.1. Three new BlueGigaModule-based exceptions (Timeout/RemoteError/Disconnected) that are thrown on Timeout/Remote BLE instance returning an error code/disconnect respectively.

The RemoteError is of use in particular as it allows users' code to implement fallback and recovery mechanisms in case of an error.

1.2. BLEScanResponse no longer fails with KeyError when device returns an advanced data segment with an unknown code. The adv_segment field now contains `AdvancedSegment` namedtuples instead of dictionaries with each element providing original adv_segment code (int), "name" string (can be `None` if adv_segment code is not known) and the data payload.

1.3. The `ProcedureCallHandle` is no longer keeping track of function call contexts and respective return codes.  The library now uses `ProcedureManager` object for the purpose and it is able to track several simultaneous call types as a result (e.g. you can have both `PROCEDURE` and `WRITE_ATTRIBUTE` function calls active simultaneously.

1.4. procedure_start & procedure_wait function is replaced with Python context. Context is better for the purpose as you can't forget to do procedure_wait on exit.

1.5. the disconnect() function is no longer blindly closes first eight connection handles. Instead it now blindly closes first eight connection handles AND any other connections currently open.

1.6. BLE Connections are now notified when they're closed with the user being able to identify this as well via calling `<connection>.is_connected()` method.

2. bgapi/api.py 

The incoming data parsing thread no longer just gives up upon failing to parse an BGAPI packet.

3. bgapi/cmd_def.py 

The RESULT_CODE & Co dictionaries now never fail to provide a string name for your result code.
This helps when token reports unexpected bytes in place of result codes.
