### PR TITLE
Added i/o rate limiting according to the connection interval & remote…

### DIFF
--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -303,7 +303,7 @@ class BLEConnection(ProcedureManager):
         return self.interval * 1.25
 
     def set_min_connection_interval(self, interval):
-        self._min_connection_interval = float(interval)
+        self._min_connection_interval = 0 * float(interval)
 
     def get_procedure_call_interval(self):
         # Overrides `ProcedureManager`.get_procedure_call_interval
@@ -578,6 +578,11 @@ class BlueGigaModule(BlueGigaCallbacks, ProcedureManager):
             self.connections[connection].set_disconnected(reason)
         self.procedure_complete(DISCONNECT, result=reason)
 
+    def ble_rsp_gap_connect_direct(self, result, connection_handle):
+        super(BlueGigaModule, self).ble_rsp_gap_connect_direct(result, connection_handle)
+        if result and connection_handle in self.connections:
+            self.connections[connection_handle].set_disconnected(result)
+            self.procedure_complete(CONNECT, result=result)
 
 class BlueGigaClient(BlueGigaModule):
     def connect_by_adv_data(self, adv_data, scan_timeout=3, conn_interval_min=0x20, conn_interval_max=0x30, connection_timeout=100, latency=0):

--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -373,9 +373,19 @@ class BLEConnection(ProcedureManager):
             self._api.ble_cmd_attclient_read_by_type(self.handle, service.start_handle, service.end_handle, type)
 
     @connected
+    def read_all_characteristics_by_type(self, type, timeout=3):
+        with self.procedure_call(PROCEDURE, timeout):
+            self._api.ble_cmd_attclient_read_by_type(self.handle, 0x0001, 0xFFFF, type)
+
+    @connected
     def find_information(self, service, timeout=5):
         with self.procedure_call(PROCEDURE, timeout):
             self._api.ble_cmd_attclient_find_information(self.handle, service.start_handle, service.end_handle)
+
+    @connected
+    def find_all_information(self, timeout=5):
+        with self.procedure_call(PROCEDURE, timeout):
+            self._api.ble_cmd_attclient_find_information(self.handle, 0x0001, 0xFFFF)
 
     @connected
     def read_by_handle(self, handle, timeout=3):

--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -285,6 +285,7 @@ class BLEConnection(ProcedureManager):
         self.handle_value = {}
         self.attrclient_value_cb = {}
         self._disconnected = None
+        self._min_connection_interval = 0
 
     def is_connected(self):
         return self._disconnected is None
@@ -301,9 +302,15 @@ class BLEConnection(ProcedureManager):
     def get_conn_interval_ms(self):
         return self.interval * 1.25
 
+    def set_min_connection_interval(self, interval):
+        self._min_connection_interval = float(interval)
+
     def get_procedure_call_interval(self):
         # Overrides `ProcedureManager`.get_procedure_call_interval
-        return self.get_conn_interval_ms() / 1000.0
+        return max(
+            self._min_connection_interval,
+            self.get_conn_interval_ms() / 1000.0,
+        )
 
     def get_timeout_ms(self):
         return self.timeout * 10


### PR DESCRIPTION
1. Host connection no longer can overload remote device by exceeding connection interval

1. Remote exception is now raised in the thread waiting in the `procedure_call` if remote device disconnects