### PR TITLE
fixed a wrong waiting loop inside procedure_call

### DIFF
--- a/bgapi/module.py
+++ b/bgapi/module.py
@@ -242,8 +242,10 @@ class ProcedureManager(object):
             # Ensure that the lib does not exceed connection interval.
             earliest_interval_ts = self.ioTimestamps[procedure_type][0]
             interval = self.get_procedure_call_interval()
-            while (time.time() - earliest_interval_ts) < interval:
-                time.sleep(max(0.01, time.time() - earliest_interval_ts))
+            wait_until = earliest_interval_ts + interval
+            now = time.time()
+            if now<wait_until:
+                time.sleep(max(0.00125, wait_until - now))
 
             try:
 


### PR DESCRIPTION
The sleep inside the while-loop will sleep more, the longer the earliest interval timestamp has passed. Worse, if there is a context switch between the while condition and the sleep, the sleep will be even longer. In rare cases (particularly when the python process is running a GUI, and the PC is otherwise busy), we have observed waiting times of several seconds (10+) in this loop.